### PR TITLE
Use clang to compile

### DIFF
--- a/master/debian/rules
+++ b/master/debian/rules
@@ -6,6 +6,8 @@ export DH_VERBOSE=1
 
 # scons flags
 SCONS_FLAGS=INPUT_PLUGINS=csv,gdal,geojson,topojson,ogr,osm,postgis,raster,shape,sqlite \
+CC=/usr/bin/clang \
+CXX=/usr/bin/clang++ \
 CUSTOM_CXXFLAGS="-fvisibility-inlines-hidden -fvisibility=hidden" \
 CAIRO=True \
 COLOR_PRINT=False \


### PR DESCRIPTION
On both my 12.04 and 14.04 systems, clang is in the same path (clang 3.4 installed)

Part of #2 to fix mapnik-packaging#170

I couldn't test this fix (instructions failed on #3), and my environment probably differs production anyways
