### PR TITLE
Update readme to reflect current PPAs and repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ the correctly named PPA's:
 
 10) Re-run a single trunk build because you've fixed debian/ stuff, do
    
-    ./nightly-builds.sh -f -b trunk -r 2
+    ./nightly-build.sh -f -b trunk -r 2
 
 
 ## Notes


### PR DESCRIPTION
The debian packaging is in its own repo now, and the branches being build have changed.
