### PR TITLE
Don't run dh_auto_configure

### DIFF
--- a/master/debian/rules
+++ b/master/debian/rules
@@ -34,7 +34,6 @@ endif
 
 override_dh_auto_configure:
 	./configure $(SCONS_FLAGS) CUSTOM_CXXFLAGS="$(CFLAGS)"
-	dh_auto_configure
 
 # Do no build for every possible python version until this is working properly
 # https://github.com/mapnik/mapnik-packaging/issues/3


### PR DESCRIPTION
This calls ./configure with a set of options more suitable for gnu autotools and overrides the scons flags above.

For some reason this wasn't an issue on 14.04, but was on 12.04
