### PR TITLE
Use two jobs for building

### DIFF
--- a/master/debian/rules
+++ b/master/debian/rules
@@ -49,6 +49,9 @@ override_dh_auto_configure:
 #
 #	dh_auto_build
 
+override_dh_auto_build:
+	JOBS=2 make
+
 override_dh_prep:
 	dh_prep -Xdebian/tmp
 


### PR DESCRIPTION
This is untested, but should work. We don't want to call dh_auto_build, since the launchpad VMs don't have enough memory for 4 jobs.
